### PR TITLE
docs: remove enterprise adoption and event-driven hooks mentions

### DIFF
--- a/docs.specs.md/methodology/sdlc-reimagined.mdx
+++ b/docs.specs.md/methodology/sdlc-reimagined.mdx
@@ -206,7 +206,6 @@ AI-DLC isn't a tool—it's a **methodology** that includes:
 - **Design integration** (DDD as core, not optional)
 - **Reversed conversation** (AI proposes, human validates)
 - **New artifacts** (Intents, Units, Bolts)
-- **Enterprise adoption path** (already used by Wipro, S&P Global, NASDAQ)
 
 ---
 
@@ -231,7 +230,6 @@ AI-DLC isn't a tool—it's a **methodology** that includes:
     For simpler projects and teams wanting a lighter entry point.
 
     - Kiro-style workflow: Requirements → Design → Tasks
-    - Event-driven agent hooks
     - Graduate to full AI-DLC when complexity demands
   </Card>
 </CardGroup>


### PR DESCRIPTION
Remove "Enterprise adoption path" and "Event-driven agent hooks"
bullet points from the SDLC reimagined page.