### PR TITLE
feat: add local dependency check scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Root workspace for specsmd development",
   "scripts": {
     "validate:all": "cd src && npm run validate:all",
-    "lint:md:fix": "cd src && npm run lint:md:fix"
-
+    "lint:md:fix": "cd src && npm run lint:md:fix",
+    "deps:check": "echo '\\n=== NPM Package (src/) ===' && npx npm-check-updates --cwd src && echo '\\n=== VS Code Extension ===' && npx npm-check-updates --cwd vs-code-extension",
+    "deps:check:minor": "echo '\\n=== NPM Package (src/) ===' && npx npm-check-updates --cwd src --target minor && echo '\\n=== VS Code Extension ===' && npx npm-check-updates --cwd vs-code-extension --target minor"
   }
 }


### PR DESCRIPTION
## Summary

Adds npm scripts to check for dependency updates locally without auto-updating or creating PRs.

## Scripts Added

| Command | Description |
|---------|-------------|
| `npm run deps:check` | Show all available updates (including major/breaking) |
| `npm run deps:check:minor` | Show only minor/patch updates (safer) |

Uses `npm-check-updates` (ncu) to scan both `src/` and `vs-code-extension/` packages.

## Example Output

```
=== NPM Package (src/) ===
 @types/node       ^24.10.2  →  ^25.0.3
 chalk               ^4.1.2  →   ^5.6.2
 ...

=== VS Code Extension ===
 @types/vscode      ^1.85.0  →  ^1.107.0
 mocha             ^10.2.0  →   ^11.7.5
 ...
```

## Test plan

- [x] Run `npm run deps:check` - shows available updates
- [x] Run `npm run deps:check:minor` - shows only minor/patch updates