### PR TITLE
fix: update VS Code extension publisher to fabriqaai

### DIFF
--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -2,8 +2,8 @@
     "name": "specsmd",
     "displayName": "specsmd extension",
     "description": "Dashboard sidebar for browsing AI-DLC memory-bank artifacts",
-    "version": "0.0.1",
-    "publisher": "specsmd",
+    "version": "0.0.2",
+    "publisher": "fabriqaai",
     "repository": {
         "type": "git",
         "url": "https://github.com/fabriqaai/specsmd.git"


### PR DESCRIPTION
## Summary

- Change publisher from `specsmd` to `fabriqaai` (matching existing marketplace publisher)
- Bump version to 0.0.2 to trigger new publish

This will allow the extension to be published to the VS Code Marketplace.