### PR TITLE
feat: attach VSIX to GitHub releases

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -92,22 +92,23 @@ jobs:
         working-directory: vs-code-extension
         run: npx vsce publish -p ${{ secrets.VSCE_PAT }}
 
-      - name: Create Git tag
+      - name: Create GitHub Release with VSIX
         if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Use --force to handle race condition - if tag exists, we skip anyway
+          # Create tag
           git tag -a "vscode-v${{ steps.version.outputs.version }}" -m "VS Code Extension v${{ steps.version.outputs.version }}" || true
           git push origin "vscode-v${{ steps.version.outputs.version }}" || echo "Tag already exists on remote"
+          # Create GitHub release with VSIX attached
+          gh release create "vscode-v${{ steps.version.outputs.version }}" \
+            --title "VS Code Extension v${{ steps.version.outputs.version }}" \
+            --notes "## specsmd VS Code Extension v${{ steps.version.outputs.version }}
 
-      - name: Upload VSIX artifact
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/upload-artifact@v4
-        with:
-          name: specsmd-${{ steps.version.outputs.version }}.vsix
-          path: vs-code-extension/*.vsix
-          retention-days: 90
+          Install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=fabriqaai.specsmd) or download the VSIX below." \
+            vs-code-extension/*.vsix
 
       - name: Skip message
         if: steps.tag_check.outputs.exists == 'true'


### PR DESCRIPTION
## Summary

After publishing to VS Code Marketplace, create a GitHub Release with the VSIX file attached.

## Changes

- Replace artifact upload with GitHub Release creation
- VSIX file attached to release for direct download
- Release notes link to VS Code Marketplace

## Example Release

```
## specsmd VS Code Extension v0.0.3

Install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=fabriqaai.specsmd) or download the VSIX below.
```