### PR TITLE
feat: rename extension to specsmd - Memory Bank Extension

### DIFF
--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -1,8 +1,8 @@
 {
     "name": "specsmd",
-    "displayName": "specsmd extension",
+    "displayName": "specsmd - Memory Bank Extension - Spec Driven Development",
     "description": "Dashboard sidebar for browsing AI-DLC memory-bank artifacts",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "fabriqaai",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

- Rename extension display name to "specsmd - Memory Bank Extension - Spec Driven Development"
- Bump version to 0.0.3

This will update the extension name on VS Code Marketplace.