### PR TITLE
feat: add extension icon and bump to v0.0.4

### DIFF
--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -2,8 +2,9 @@
     "name": "specsmd",
     "displayName": "specsmd - Memory Bank Extension - Spec Driven Development",
     "description": "Dashboard sidebar for browsing AI-DLC memory-bank artifacts",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "fabriqaai",
+    "icon": "resources/favicon.png",
     "repository": {
         "type": "git",
         "url": "https://github.com/fabriqaai/specsmd.git"


### PR DESCRIPTION
## Summary

- Add marketplace icon using existing `resources/favicon.png`
- Bump version to 0.0.4

The icon will be displayed on the VS Code Marketplace listing.