### PR TITLE
docs: remove regulated environment claim from comparisons

### DIFF
--- a/docs.specs.md/compare/vs-bmad.mdx
+++ b/docs.specs.md/compare/vs-bmad.mdx
@@ -41,7 +41,6 @@ Both **specs.md (AI-DLC)** and **BMAD-Method** target complex systems and enterp
     - You want DDD as an integral part (not optional)
     - You value collocated Mob rituals
     - You want to avoid managing 19 agents
-    - You're in a regulated environment
     - You want a [VS Code extension](/getting-started/vscode-extension) to track progress visually
   </Card>
   <Card title="Choose BMAD if:" icon="check">

--- a/docs.specs.md/compare/vs-openspec.mdx
+++ b/docs.specs.md/compare/vs-openspec.mdx
@@ -36,7 +36,6 @@ description: "Compare specs.md with OpenSpec's change-centric approach"
     - You're building new features (greenfield)
     - You want DDD integration
     - You need Mob rituals for team alignment
-    - You're in a regulated environment
     - You want formal methodology structure
     - You want a [VS Code extension](/getting-started/vscode-extension) to track progress visually
   </Card>


### PR DESCRIPTION
## Summary

Remove "You're in a regulated environment" from the "When to Choose specs.md" sections in comparison pages.

## Changes

- Remove from vs-openspec.mdx
- Remove from vs-bmad.mdx