### PR TITLE
fix: VS Code extension v0.0.6 - marketplace image and docs link

### DIFF
--- a/vs-code-extension/CHANGELOG.md
+++ b/vs-code-extension/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the specsmd VS Code extension will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2025-12-27
+
+### Added
+- Link to full documentation at specs.md
+
+### Fixed
+- Use absolute URL for preview image (fixes marketplace display)
+
 ## [0.0.5] - 2025-12-27
 
 ### Changed

--- a/vs-code-extension/README.md
+++ b/vs-code-extension/README.md
@@ -4,6 +4,8 @@
 
 A VS Code extension for managing AI-DLC (AI Development Life Cycle) artifacts including intents, units, stories, and bolts.
 
+**[Full Documentation](https://specs.md/getting-started/vscode-extension)**
+
 ![Extension Preview](https://raw.githubusercontent.com/fabriqaai/specs.md/main/vs-code-extension/resources/extension-preview.png)
 
 ## Sidebar Views

--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -2,7 +2,7 @@
     "name": "specsmd",
     "displayName": "specsmd - Memory Bank Extension - Spec Driven Development",
     "description": "Dashboard sidebar for browsing AI-DLC memory-bank artifacts",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "publisher": "fabriqaai",
     "icon": "resources/favicon.png",
     "homepage": "https://specs.md",


### PR DESCRIPTION
## Summary

Fix marketplace preview image display and add documentation link.

## Changes

- Use absolute GitHub URL for preview image (fixes marketplace display)
- Add link to full documentation at https://specs.md/getting-started/vscode-extension
- Bump version to 0.0.6
- Remove "regulated environment" claim from comparison docs

## Preview

The extension preview image should now display correctly on:
https://marketplace.visualstudio.com/items?itemName=fabriqaai.specsmd