### PR TITLE
docs: split VS Code extension dev content to DEVGUIDE.md

### DIFF
--- a/vs-code-extension/DEVGUIDE.md
+++ b/vs-code-extension/DEVGUIDE.md
@@ -1,0 +1,103 @@
+# SpecsMD VS Code Extension - Developer Guide
+
+This guide covers architecture, development setup, and publishing for maintainers.
+
+## Architecture
+
+The extension uses a hybrid rendering approach:
+- **Bolts view**: Lit web components with reactive data binding
+- **Specs/Overview views**: Server-rendered HTML with event delegation
+
+This allows for rich interactivity in the Bolts view while keeping Specs/Overview lightweight.
+
+### State Flow
+
+```
+File Watcher → Parser → StateStore → Selectors → WebviewProvider → Webview
+                              ↓
+                       [Computed State]
+                              ↓
+    ┌─────────────────────────┼─────────────────────────┐
+    │                         │                         │
+currentIntent            activeBolts              activityFeed
+pendingBolts            completedBolts            nextActions
+boltStats               overallProgress
+```
+
+---
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Compile TypeScript and bundle webview
+npm run compile
+
+# Watch for changes
+npm run watch
+
+# Run tests
+npm test
+```
+
+## File Structure
+
+```
+src/
+├── sidebar/           # Extension host code
+│   ├── webviewProvider.ts   # Main provider
+│   └── webviewMessaging.ts  # Message types
+├── webview/           # Webview UI code
+│   ├── components/    # Lit components
+│   │   ├── app.ts     # Root component
+│   │   ├── tabs/      # Tab navigation
+│   │   └── bolts/     # Bolts view components
+│   ├── html.ts        # Server-rendered HTML generators
+│   └── styles.ts      # CSS styles
+├── parser/            # Memory bank parsing
+│   ├── artifactParser.ts    # Parse intents/units/stories/bolts
+│   ├── activityFeed.ts      # Derive activity events
+│   └── dependencyComputation.ts  # Compute bolt dependencies
+└── state/             # Centralized state management
+    ├── stateStore.ts  # State container
+    ├── selectors.ts   # Computed state derivation
+    └── types.ts       # Type definitions
+```
+
+---
+
+## Publishing (Maintainers)
+
+The extension is automatically published to the VS Code Marketplace when changes are merged to `main`.
+
+### Setup VSCE_PAT Secret
+
+To enable automated publishing, configure the `VSCE_PAT` secret:
+
+1. **Create Azure DevOps Organization** (if needed)
+   - Go to https://dev.azure.com
+   - Sign in with your Microsoft account
+   - Create a new organization if you don't have one
+
+2. **Create Personal Access Token**
+   - Click your profile icon (top right) → "Personal access tokens"
+   - Click "+ New Token"
+   - Configure:
+     - **Name**: `vscode-marketplace`
+     - **Organization**: Select **"All accessible organizations"** (required for CLI publishing)
+     - **Expiration**: Set as needed (max 1 year)
+     - **Scopes**: Click "Show all scopes" → scroll to "Marketplace" → check **"Manage"**
+   - Click "Create" and **copy the token immediately**
+
+3. **Create Publisher** (if needed)
+   - Go to https://marketplace.visualstudio.com/manage
+   - Sign in with the same Microsoft account
+   - Create publisher with ID `specsmd`
+
+4. **Add Secret to GitHub**
+   - Go to repository Settings → Secrets → Actions
+   - Click "New repository secret"
+   - Name: `VSCE_PAT`
+   - Value: Paste your token

--- a/vs-code-extension/README.md
+++ b/vs-code-extension/README.md
@@ -4,7 +4,7 @@
 
 A VS Code extension for managing AI-DLC (AI Development Life Cycle) artifacts including intents, units, stories, and bolts.
 
-**[Full Documentation](https://specs.md/getting-started/vscode-extension)**
+**[Visit specs.md](https://specs.md)** | **[Full Documentation](https://specs.md/getting-started/vscode-extension)**
 
 ![Extension Preview](https://raw.githubusercontent.com/fabriqaai/specs.md/main/vs-code-extension/resources/extension-preview.png)
 
@@ -54,6 +54,7 @@ Shows pending bolts ready to be started.
 Timeline of bolt and stage completions.
 
 **Event Types:**
+
 | Event | Source | Icon |
 |-------|--------|------|
 | `bolt-created` | `created` timestamp in bolt frontmatter | + |
@@ -91,6 +92,7 @@ Intent (🎯) → Units (📚) → Stories (📝)
 - Progress indicators show completion percentage for each intent
 
 **Status Indicators:**
+
 | Status | Icon | Color |
 |--------|------|-------|
 | Complete | ✓ | Green |
@@ -121,13 +123,13 @@ AI-recommended next steps based on current project state.
 **Action Types and Selection Rules:**
 
 | Priority | Action | Condition |
-|----------|--------|-----------|
-| 1 | **Continue Current Bolt** | Active bolt exists (`status: in-progress`) |
-| 1 | **Start Next Bolt** | No active bolt AND unblocked bolts in queue |
-| 2 | **Complete Stage** | Active bolt has a `currentStage` set |
-| 3 | **Unblock Multiple Bolts** | A blocking bolt would unblock 2+ waiting bolts |
-| 4 | **Create Bolt for Pending Work** | Intent has pending stories but no active/draft bolts |
-| 1 | **Celebrate!** | All bolts complete AND all intents complete |
+|:---------|:-------|:----------|
+| 1 | Continue Current Bolt | Active bolt exists (`status: in-progress`) |
+| 1 | Start Next Bolt | No active bolt AND unblocked bolts in queue |
+| 2 | Complete Stage | Active bolt has a `currentStage` set |
+| 3 | Unblock Multiple Bolts | A blocking bolt would unblock 2+ waiting bolts |
+| 4 | Create Bolt for Pending Work | Intent has pending stories but no active/draft bolts |
+| 1 | Celebrate! | All bolts complete AND all intents complete |
 
 **Selection Algorithm:**
 ```
@@ -144,12 +146,12 @@ AI-recommended next steps based on current project state.
 The "current intent" shown in the header uses a priority cascade:
 
 | Priority | Strategy | Description |
-|----------|----------|-------------|
-| 1 | **Active Bolt** | Intent containing a bolt with `status: in-progress` |
-| 2 | **Recent Activity** | Intent with most recent bolt timestamp (completed > started > created) |
-| 3 | **In-Progress Stories** | Intent with most stories having `status: in-progress` |
-| 4 | **Incomplete Work** | First intent with `status: in-progress` or `status: draft` |
-| 5 | **Fallback** | First intent in list |
+|:---------|:---------|:------------|
+| 1 | Active Bolt | Intent containing a bolt with `status: in-progress` |
+| 2 | Recent Activity | Intent with most recent bolt timestamp (completed > started > created) |
+| 3 | In-Progress Stories | Intent with most stories having `status: in-progress` |
+| 4 | Incomplete Work | First intent with `status: in-progress` or `status: draft` |
+| 5 | Fallback | First intent in list |
 
 ---
 
@@ -188,102 +190,6 @@ Tabs persist across VS Code sessions. The extension saves your active tab choice
 
 ---
 
-## Architecture
+## Contributing
 
-The extension uses a hybrid rendering approach:
-- **Bolts view**: Lit web components with reactive data binding
-- **Specs/Overview views**: Server-rendered HTML with event delegation
-
-This allows for rich interactivity in the Bolts view while keeping Specs/Overview lightweight.
-
-### State Flow
-
-```
-File Watcher → Parser → StateStore → Selectors → WebviewProvider → Webview
-                              ↓
-                       [Computed State]
-                              ↓
-    ┌─────────────────────────┼─────────────────────────┐
-    │                         │                         │
-currentIntent            activeBolts              activityFeed
-pendingBolts            completedBolts            nextActions
-boltStats               overallProgress
-```
-
----
-
-## Development
-
-```bash
-# Install dependencies
-npm install
-
-# Compile TypeScript and bundle webview
-npm run compile
-
-# Watch for changes
-npm run watch
-
-# Run tests
-npm test
-```
-
-## File Structure
-
-```
-src/
-├── sidebar/           # Extension host code
-│   ├── webviewProvider.ts   # Main provider
-│   └── webviewMessaging.ts  # Message types
-├── webview/           # Webview UI code
-│   ├── components/    # Lit components
-│   │   ├── app.ts     # Root component
-│   │   ├── tabs/      # Tab navigation
-│   │   └── bolts/     # Bolts view components
-│   ├── html.ts        # Server-rendered HTML generators
-│   └── styles.ts      # CSS styles
-├── parser/            # Memory bank parsing
-│   ├── artifactParser.ts    # Parse intents/units/stories/bolts
-│   ├── activityFeed.ts      # Derive activity events
-│   └── dependencyComputation.ts  # Compute bolt dependencies
-└── state/             # Centralized state management
-    ├── stateStore.ts  # State container
-    ├── selectors.ts   # Computed state derivation
-    └── types.ts       # Type definitions
-```
-
----
-
-## Publishing (Maintainers)
-
-The extension is automatically published to the VS Code Marketplace when changes are merged to `main`.
-
-### Setup VSCE_PAT Secret
-
-To enable automated publishing, configure the `VSCE_PAT` secret:
-
-1. **Create Azure DevOps Organization** (if needed)
-   - Go to https://dev.azure.com
-   - Sign in with your Microsoft account
-   - Create a new organization if you don't have one
-
-2. **Create Personal Access Token**
-   - Click your profile icon (top right) → "Personal access tokens"
-   - Click "+ New Token"
-   - Configure:
-     - **Name**: `vscode-marketplace`
-     - **Organization**: Select **"All accessible organizations"** (required for CLI publishing)
-     - **Expiration**: Set as needed (max 1 year)
-     - **Scopes**: Click "Show all scopes" → scroll to "Marketplace" → check **"Manage"**
-   - Click "Create" and **copy the token immediately**
-
-3. **Create Publisher** (if needed)
-   - Go to https://marketplace.visualstudio.com/manage
-   - Sign in with the same Microsoft account
-   - Create publisher with ID `specsmd`
-
-4. **Add Secret to GitHub**
-   - Go to repository Settings → Secrets → Actions
-   - Click "New repository secret"
-   - Name: `VSCE_PAT`
-   - Value: Paste your token
+For architecture details, development setup, and publishing instructions, see the [Developer Guide](./DEVGUIDE.md).


### PR DESCRIPTION
## Summary
- Move architecture, development setup, and publishing instructions to separate DEVGUIDE.md
- Fix table rendering by adding blank lines before tables (required by some markdown parsers)
- Add specs.md website link to README header
- Keep README focused on user-facing documentation for marketplace

## Test plan
- [ ] Verify README renders correctly on VS Code marketplace
- [ ] Verify DEVGUIDE.md is accessible for contributors