### PR TITLE
docs: fix IDE compatibility info - Google Antigravity URL and IDX warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Track your AI-DLC progress with our sidebar extension for VS Code and compatible
   <img src="vs-code-extension/resources/extension-preview.png" alt="VS Code Extension Preview" width="800" />
 </p>
 
-> **Note:** Works with any VS Code-based IDE including [Cursor](https://cursor.sh), [Google Antigravity](https://idx.dev), [Windsurf](https://codeium.com/windsurf), and others.
+> **Note:** Works with any VS Code-based IDE including [Cursor](https://cursor.sh), [Google Antigravity](https://antigravity.google), [Windsurf](https://codeium.com/windsurf), and others.
 
 **Install from:**
 - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=fabriqaai.specsmd)

--- a/docs.specs.md/getting-started/vscode-extension.mdx
+++ b/docs.specs.md/getting-started/vscode-extension.mdx
@@ -14,8 +14,12 @@ The specsmd VS Code extension provides a visual dashboard for tracking your AI-D
 />
 
 <Info>
-  Works with any VS Code-based IDE including [Cursor](https://cursor.sh), [Windsurf](https://codeium.com/windsurf), and [Google IDX](https://idx.dev).
+  Works with VS Code-based IDEs including [Cursor](https://cursor.sh), [Google Antigravity](https://antigravity.google), [Windsurf](https://codeium.com/windsurf), [GitHub Codespaces](https://github.com/features/codespaces), [Gitpod](https://gitpod.io), and [Amazon Kiro](https://kiro.dev).
 </Info>
+
+<Warning>
+  **Google IDX is not supported.** While IDX uses Monaco (VS Code's editor), it has a different extension architecture and uses the Open VSX registry instead of the VS Code Marketplace. Many VS Code extensions, including specsmd, don't work or behave differently in IDX.
+</Warning>
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fixed Google Antigravity URL from `idx.dev` to `antigravity.google` (correct product URL)
- Added warning that Google IDX is not supported (uses Open VSX registry, different extension architecture)
- Added GitHub Codespaces, Gitpod, and Amazon Kiro to the list of supported VS Code-based IDEs

## Test plan
- [ ] Verify links work correctly in rendered docs
- [ ] Confirm IDX warning displays properly in Mintlify preview