### PR TITLE
fix: match intent by combined format in selector

### DIFF
--- a/vs-code-extension/src/state/selectors.ts
+++ b/vs-code-extension/src/state/selectors.ts
@@ -30,10 +30,13 @@ import {
 export type IntentSelectionStrategy = (intents: Intent[], bolts: Bolt[]) => Intent | null;
 
 /**
- * Helper: Match intent by number or name.
+ * Helper: Match intent by number, name, or combined format (e.g., "007-installer-analytics").
  */
 function matchIntent(intent: Intent, identifier: string): boolean {
-    return intent.number === identifier || intent.name === identifier;
+    const combined = `${intent.number}-${intent.name}`;
+    return intent.number === identifier
+        || intent.name === identifier
+        || combined === identifier;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes current intent detection when bolts store intent in combined format (e.g., `007-installer-analytics`)
- The `matchIntent` helper now checks number, name, AND combined format

## Problem

The bolt frontmatter stores intent as `007-installer-analytics` but the Intent object has separate fields:
- `intent.number` = `"007"`
- `intent.name` = `"installer-analytics"`

The previous matching logic only checked these fields separately, causing the match to fail.

## Test plan

- [x] All 264 existing tests pass
- [ ] Verify in VS Code that current intent matches the focused bolt's intent