### PR TITLE
fix: use GH_PAT for CI push to protected main branch

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -91,7 +91,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           # Create tag
           git tag -a "v${{ steps.version.outputs.version }}" -m "specsmd v${{ steps.version.outputs.version }}"

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create GitHub Release with VSIX
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           # Create tag
           git tag -a "vscode-v${{ steps.version.outputs.version }}" -m "VS Code Extension v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

Update CI workflows to use `GH_PAT` secret instead of `GITHUB_TOKEN` for push operations.

`GITHUB_TOKEN` cannot bypass branch protection rules, causing version bump commits to fail.

## Changes

- `npm-package-release.yml`: Use `GH_PAT` for checkout and release creation
- `vscode-publish.yml`: Use `GH_PAT` for checkout and release creation

## Required

Add `GH_PAT` secret to repository:
1. Create PAT at https://github.com/settings/tokens?type=beta
2. Grant `contents: write` permission for this repo
3. Add as secret named `GH_PAT` at https://github.com/fabriqaai/specs.md/settings/secrets/actions