### PR TITLE
fix: ensure analytics events are sent before process exit

### DIFF
--- a/src/lib/installer.js
+++ b/src/lib/installer.js
@@ -70,7 +70,7 @@ async function detectTools() {
 async function install() {
   // Initialize analytics (respects opt-out env vars)
   analytics.init();
-  analytics.trackInstallerStarted();
+  await analytics.trackInstallerStarted();
 
   const installStartTime = Date.now();
 
@@ -119,8 +119,8 @@ async function install() {
     process.exit(1);
   }
 
-  // Track IDE selection
-  analytics.trackIdesConfirmed(selectedToolKeys);
+  // Track IDE selection (await to ensure delivery before potential cancel)
+  await analytics.trackIdesConfirmed(selectedToolKeys);
 
   // Step 3: Select Flow
   console.log('');
@@ -143,8 +143,8 @@ async function install() {
     process.exit(1);
   }
 
-  // Track flow selection
-  analytics.trackFlowSelected(selectedFlow);
+  // Track flow selection (await to ensure delivery before potential cancel)
+  await analytics.trackFlowSelected(selectedFlow);
 
   // Step 4: Install flow files
   console.log('');


### PR DESCRIPTION
## Summary

Fix analytics events being lost when user cancels installation mid-way.

## Problem

Mixpanel SDK batches events and sends them asynchronously. If user hits Ctrl+C before the buffer flushes, funnel events are lost.

## Solution

- Added `waitForDelivery` parameter to `track()` method
- Critical funnel events (`installer_started`, `ides_confirmed`, `flow_selected`) now wait for delivery confirmation
- Updated installer.js to `await` these tracking calls

Now if user:
1. Starts installer → `installer_started` ✅ sent immediately
2. Selects IDEs → `ides_confirmed` ✅ sent immediately  
3. Cancels → events are already delivered

## Test plan

- [x] All 62 tests pass
- [ ] Manual test: start installer, select IDEs, cancel, verify events in Mixpanel