### PR TITLE
docs: add community page with Discord and X links

### DIFF
--- a/docs.specs.md/community.mdx
+++ b/docs.specs.md/community.mdx
@@ -1,0 +1,64 @@
+---
+title: Community
+description: Join the specs.md community - Connect with developers building AI-native software
+---
+
+# Community
+
+Join our growing community of developers building AI-native software with specs.md.
+
+<CardGroup cols={2}>
+  <Card
+    title="Discord"
+    icon="discord"
+    href="https://discord.gg/X8pfZpZHnR"
+  >
+    Join our Discord server to chat with the community, get help, and share your experiences.
+  </Card>
+  <Card
+    title="X (Twitter)"
+    icon="x-twitter"
+    href="https://x.com/specsmd"
+  >
+    Follow us on X for updates, tips, and announcements.
+  </Card>
+</CardGroup>
+
+## Get Involved
+
+<CardGroup cols={2}>
+  <Card
+    title="GitHub"
+    icon="github"
+    href="https://github.com/fabriqaai/specs.md"
+  >
+    Star the repo, report issues, or contribute to the project.
+  </Card>
+  <Card
+    title="Feedback"
+    icon="comment"
+    href="/feedback"
+  >
+    Share your thoughts and help us improve specs.md.
+  </Card>
+</CardGroup>
+
+## Why Join?
+
+- **Get Help**: Ask questions and get answers from the community and maintainers
+- **Share Knowledge**: Help others and share your AI-DLC experiences
+- **Stay Updated**: Be the first to know about new features and releases
+- **Shape the Future**: Your feedback directly influences the roadmap
+
+## Community Guidelines
+
+We're committed to providing a welcoming and inclusive environment. Please:
+
+- Be respectful and constructive
+- Help others when you can
+- Share your learnings and experiences
+- Report any issues or concerns
+
+<Info>
+  We're just getting started! Join early and help shape the community.
+</Info>

--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -108,7 +108,8 @@
             "group": "Resources",
             "pages": [
               "faq",
-              "feedback"
+              "feedback",
+              "community"
             ]
           }
         ]
@@ -117,7 +118,9 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/fabriqaai/specs.md"
+      "github": "https://github.com/fabriqaai/specs.md",
+      "discord": "https://discord.gg/X8pfZpZHnR",
+      "x": "https://x.com/specsmd"
     }
   },
   "integrations": {


### PR DESCRIPTION
## Summary
- Create community.mdx page with links to Discord server and X (Twitter)
- Add community page to Resources navigation group
- Add Discord and X social icons to documentation footer

## Links
- Discord: https://discord.gg/X8pfZpZHnR
- X: https://x.com/specsmd

## Test plan
- [ ] Verify community page renders correctly
- [ ] Verify Discord and X links work
- [ ] Verify footer shows Discord and X icons