### PR TITLE
feat: add Product Hunt links and embed to docs

### DIFF
--- a/docs.specs.md/community.mdx
+++ b/docs.specs.md/community.mdx
@@ -7,7 +7,7 @@ description: Join the specs.md community - Connect with developers building AI-n
 
 Join our growing community of developers building AI-native software with specs.md.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Discord"
     icon="discord"
@@ -22,7 +22,27 @@ Join our growing community of developers building AI-native software with specs.
   >
     Follow us on X for updates, tips, and announcements.
   </Card>
+  <Card
+    title="Product Hunt"
+    icon="rocket"
+    href="https://www.producthunt.com/products/specs-md"
+  >
+    Check out our Product Hunt page and leave a review.
+  </Card>
 </CardGroup>
+
+## Featured on Product Hunt
+
+<div style={{fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif', border: '1px solid rgb(224, 224, 224)', borderRadius: '12px', padding: '20px', maxWidth: '500px', background: 'rgb(255, 255, 255)', boxShadow: 'rgba(0, 0, 0, 0.05) 0px 2px 8px'}}>
+  <div style={{display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px'}}>
+    <img alt="specs.md" src="https://ph-files.imgix.net/c27cd4d3-2430-4666-bb60-dd29a5646afd.png?auto=format&amp;fit=crop&amp;w=80&amp;h=80" style={{width: '64px', height: '64px', borderRadius: '8px', objectFit: 'cover', flexShrink: 0}} />
+    <div style={{flex: '1 1 0%', minWidth: '0px'}}>
+      <h3 style={{margin: '0px', fontSize: '18px', fontWeight: '600', color: 'rgb(26, 26, 26)', lineHeight: '1.3', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>specs.md</h3>
+      <p style={{margin: '4px 0px 0px', fontSize: '14px', color: 'rgb(102, 102, 102)', lineHeight: '1.4', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: '2', WebkitBoxOrient: 'vertical'}}>framework for spec-driven AI development with pluggable flow</p>
+    </div>
+  </div>
+  <a href="https://www.producthunt.com/products/specs-md?embed=true&amp;utm_source=embed&amp;utm_medium=post_embed" target="_blank" rel="noopener" style={{display: 'inline-flex', alignItems: 'center', gap: '4px', marginTop: '12px', padding: '8px 16px', background: 'rgb(255, 97, 84)', color: 'rgb(255, 255, 255)', textDecoration: 'none', borderRadius: '8px', fontSize: '14px', fontWeight: '600'}}>Check it out on Product Hunt →</a>
+</div>
 
 ## Get Involved
 

--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -26,6 +26,10 @@
       {
         "label": "vscode extension",
         "href": "https://marketplace.visualstudio.com/items?itemName=fabriqaai.specsmd"
+      },
+      {
+        "label": "product hunt",
+        "href": "https://www.producthunt.com/products/specs-md"
       }
     ],
     "primary": {

--- a/docs.specs.md/index.mdx
+++ b/docs.specs.md/index.mdx
@@ -173,3 +173,7 @@ Traditional development methods were built for human-driven, long-running proces
 - **Complete planning upfront** through Mob Elaboration (weeks of work in hours)
 - **Persistent context** that AI can reference across sessions
 - **Structured artifacts** that build on each other progressively
+
+<Info>
+  <strong>Featured on Product Hunt!</strong> Check out our launch and leave a review: <a href="https://www.producthunt.com/products/specs-md" target="_blank" rel="noopener">specs.md on Product Hunt →</a>
+</Info>


### PR DESCRIPTION
## Summary
- Add Product Hunt link to navbar alongside GitHub, npm, and VSCode extension
- Add Product Hunt card to community page (3-card layout with Discord, X, Product Hunt)
- Add Product Hunt embed widget to community page
- Add Product Hunt callout banner to homepage

## Test plan
- [ ] Verify navbar shows Product Hunt link
- [ ] Check community page displays card and embed widget correctly
- [ ] Confirm homepage shows Product Hunt callout