### PR TITLE
Add Slack invite link to community page

### DIFF
--- a/docs.specs.md/community.mdx
+++ b/docs.specs.md/community.mdx
@@ -7,13 +7,20 @@ description: Join the specs.md community - Connect with developers building AI-n
 
 Join our growing community of developers building AI-native software with specs.md.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Discord"
     icon="discord"
     href="https://discord.gg/X8pfZpZHnR"
   >
     Join our Discord server to chat with the community, get help, and share your experiences.
+  </Card>
+  <Card
+    title="Slack"
+    icon="slack"
+    href="https://join.slack.com/t/fabriqaai/shared_invite/zt-3mfa1vmia-NssUSnjjcvozxSVfSE2FLg"
+  >
+    Connect with the team on Slack for discussions and collaboration.
   </Card>
   <Card
     title="X (Twitter)"


### PR DESCRIPTION
## Summary
- Adds Slack card to the community page with the Fabriqa AI workspace invite link
- Updates CardGroup layout to 3 columns to accommodate the new card

## Changes
- Discord, Slack, and X (Twitter) now displayed in a 3-column grid