### PR TITLE
feat: SEO metadata, Product Hunt links, and MIT license

### DIFF
--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -2,7 +2,20 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "specs.md",
-  "description": "AI-native software development with multi-agent orchestration",
+  "description": "AI-native software development with multi-agent orchestration. Implement AI-DLC methodology with markdown-based agents for Claude Code, Cursor, and GitHub Copilot.",
+  "metadata": {
+    "og:site_name": "specs.md",
+    "og:type": "website",
+    "og:image": "/images/logo.png",
+    "og:locale": "en_US",
+    "twitter:card": "summary_large_image",
+    "twitter:site": "@specsmd",
+    "twitter:image": "/images/logo.png",
+    "keywords": "AI-DLC, AI-native development, software development lifecycle, multi-agent orchestration, Claude Code, Cursor, GitHub Copilot, Domain-Driven Design, spec-driven development"
+  },
+  "seo": {
+    "indexHiddenPages": true
+  },
   "logo": {
     "dark": "/images/logo.png",
     "light": "/images/logo.png"


### PR DESCRIPTION
## Summary

- Add SEO metadata and social sharing tags to docs (Open Graph, Twitter Cards, keywords)
- Add Product Hunt links and embed to community page and index
- Add MIT LICENSE file

## Changes

| File | Change |
|------|--------|
| `docs.specs.md/docs.json` | SEO metadata, OG tags, Twitter cards, keywords |
| `docs.specs.md/community.mdx` | Product Hunt embed |
| `docs.specs.md/index.mdx` | Product Hunt link |
| `LICENSE` | MIT license file |

## Test plan

- [ ] Verify docs deploy successfully
- [ ] Check OG preview with https://www.opengraph.xyz/
- [ ] Verify sitemap at specs.md/sitemap.xml