### PR TITLE
Replace Slack with Zulip community link

### DIFF
--- a/docs.specs.md/community.mdx
+++ b/docs.specs.md/community.mdx
@@ -16,11 +16,11 @@ Join our growing community of developers building AI-native software with specs.
     Join our Discord server to chat with the community, get help, and share your experiences.
   </Card>
   <Card
-    title="Slack"
-    icon="slack"
-    href="https://join.slack.com/t/fabriqaai/shared_invite/zt-3mfa1vmia-NssUSnjjcvozxSVfSE2FLg"
+    title="Zulip"
+    icon="comments"
+    href="https://fabriqa.zulipchat.com/"
   >
-    Connect with the team on Slack for discussions and collaboration.
+    Connect with the team on Zulip for discussions and collaboration.
   </Card>
   <Card
     title="X (Twitter)"


### PR DESCRIPTION
## Summary
- Replaced Slack invitation link with Zulip community link in the docs community page
- Updated link to https://fabriqa.zulipchat.com/

## Test plan
- [ ] Verify the Zulip link works correctly on the community page
- [ ] Confirm the icon displays properly