### PR TITLE
Add DeepWiki contextual option

### DIFF
--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -154,6 +154,12 @@
       "cursor",
       "vscode",
       {
+        "title": "Explore with DeepWiki",
+        "description": "Explore with DeepWiki",
+        "icon": "book",
+        "href": "https://deepwiki.com/fabriqaai/specs.md"
+      },
+      {
         "title": "Feature Request",
         "description": "Suggest a new feature",
         "icon": "lightbulb",


### PR DESCRIPTION
## Summary
- Added DeepWiki option to contextual menu
- Links to https://deepwiki.com/fabriqaai/specs.md

## Test plan
- [ ] Verify DeepWiki option appears in contextual menu
- [ ] Confirm link opens correct DeepWiki page