### PR TITLE
Add DeepWiki page to Resources menu

### DIFF
--- a/docs.specs.md/deepwiki.mdx
+++ b/docs.specs.md/deepwiki.mdx
@@ -1,0 +1,32 @@
+---
+title: DeepWiki
+description: Explore specs.md documentation with AI-powered DeepWiki
+---
+
+# DeepWiki
+
+Explore the specs.md codebase and documentation using DeepWiki's AI-powered interface.
+
+<Card
+  title="Open DeepWiki"
+  icon="book-open"
+  href="https://deepwiki.com/fabriqaai/specs.md"
+>
+  Ask questions, explore the codebase, and get AI-powered answers about specs.md
+</Card>
+
+## What is DeepWiki?
+
+DeepWiki provides an AI-powered interface to explore GitHub repositories. It allows you to:
+
+- **Ask questions** about the codebase in natural language
+- **Understand architecture** and how different parts connect
+- **Find code examples** and usage patterns
+- **Learn concepts** with AI-generated explanations
+
+## Why Use DeepWiki for specs.md?
+
+- Get instant answers about AI-DLC methodology
+- Understand how agents work together
+- Explore implementation details
+- Find specific code patterns and examples

--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -126,7 +126,8 @@
             "pages": [
               "faq",
               "feedback",
-              "community"
+              "community",
+              "deepwiki"
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- Added new DeepWiki page (`deepwiki.mdx`) to the documentation
- Added DeepWiki link under the Resources navigation menu
- Page explains what DeepWiki is and how to use it for exploring specs.md

## Test plan
- [ ] Verify DeepWiki page renders correctly
- [ ] Confirm link appears in Resources menu
- [ ] Test the DeepWiki external link works