### PR TITLE
docs: update Discord links to use redirect URL

### DIFF
--- a/docs.specs.md/community.mdx
+++ b/docs.specs.md/community.mdx
@@ -11,7 +11,7 @@ Join our growing community of developers building AI-native software with specs.
   <Card
     title="Discord"
     icon="discord"
-    href="https://discord.gg/X8pfZpZHnR"
+    href="http://discord.specs.md/"
   >
     Join our Discord server to chat with the community, get help, and share your experiences.
   </Card>

--- a/docs.specs.md/docs.json
+++ b/docs.specs.md/docs.json
@@ -137,7 +137,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/fabriqaai/specs.md",
-      "discord": "https://discord.gg/X8pfZpZHnR",
+      "discord": "http://discord.specs.md/",
       "x": "https://x.com/specsmd"
     }
   },


### PR DESCRIPTION
## Summary
- Update Discord links in documentation to use `discord.specs.md` redirect URL instead of direct invite links

## Test plan
- [ ] Verify links redirect correctly to Discord