### PR TITLE
Add dashboard web command

### DIFF
--- a/.github/workflows/npm-package-dev.yml
+++ b/.github/workflows/npm-package-dev.yml
@@ -26,9 +26,19 @@ jobs:
         working-directory: src
         run: npm ci
 
+      - name: Install VS Code extension dependencies
+        working-directory: vs-code-extension
+        run: npm ci
+
       - name: Run tests
         working-directory: src
         run: npm test
+
+      - name: Build and sync dashboard webview bundle
+        run: |
+          npm --prefix vs-code-extension run compile:webview
+          npm --prefix src run sync:webview-bundle
+          npm --prefix src run check:webview-bundle
 
       - name: Set incremental dev version
         working-directory: src

--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -64,6 +64,10 @@ jobs:
         working-directory: src
         run: npm ci
 
+      - name: Install VS Code extension dependencies
+        working-directory: vs-code-extension
+        run: npm ci
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -98,6 +102,12 @@ jobs:
 
       - name: Copy README to src for npm package
         run: cp README.md src/README.md
+
+      - name: Build and sync dashboard webview bundle
+        run: |
+          npm --prefix vs-code-extension run compile:webview
+          npm --prefix src run sync:webview-bundle
+          npm --prefix src run check:webview-bundle
 
       - name: Publish to npm
         working-directory: src


### PR DESCRIPTION
## Summary
- Make `specsmd dashboard` launch the local web dashboard and preserve the terminal UI as `dashboard-cli`
- Reuse the VS Code webview bundle/components for dashboard web instead of a separate browser UI
- Harden local dashboard command endpoints with token protection, origin checks, and realpath-safe file opening
- Add AI-DLC/FIRE webview adapters, docs updates, screenshots, and bundle sync guards for npm packaging
- Build and sync the webview bundle before npm dev/main publishes

## Verification
- `npm run validate:all`
- `npm pack --dry-run`
- `npm run typecheck:webview`
- `npm run compile:webview`
- Local dashboard smoke checks for shared webview loading, icon rendering, token cookie, and cross-origin rejection
- Manual `NPM Package Dev Release` workflow dispatch passed: run 27091421850
