### PR TITLE
Activity tab + Bolts intent picker

### DIFF
--- a/vs-code-extension/src/sidebar/webviewMessaging.ts
+++ b/vs-code-extension/src/sidebar/webviewMessaging.ts
@@ -110,6 +110,18 @@ export interface WebviewData {
 
     /** Available unit statuses discovered from parsed data */
     availableStatuses: string[];
+
+    /**
+     * Per-intent bolt statistics. Keys include the intent number, name, and
+     * combined `${number}-${name}` form so lookups work regardless of which
+     * identifier the webview holds.
+     */
+    intentStats: Record<string, {
+        active: number;
+        queued: number;
+        done: number;
+        blocked: number;
+    }>;
 }
 
 /**
@@ -119,6 +131,12 @@ export interface ActiveBoltData {
     id: string;
     name: string;
     type: string;
+    /** Raw bolt.intent value (may be number or name). */
+    intent: string;
+    /** Resolved intent number, e.g., "001". */
+    intentNumber: string;
+    /** Resolved intent display name. */
+    intentName: string;
     currentStage: string | null;
     stagesComplete: number;
     stagesTotal: number;
@@ -152,6 +170,12 @@ export interface QueuedBoltData {
     isBlocked: boolean;
     blockedBy: string[];
     unblocksCount: number;
+    /** Raw intent identifier on the bolt (may be the intent number or name). */
+    intent: string;
+    /** Resolved intent number prefix, e.g., "001". */
+    intentNumber: string;
+    /** Resolved intent display name, e.g., "platform-foundations". */
+    intentName: string;
     stages: {
         name: string;
         status: 'complete' | 'active' | 'pending';
@@ -240,6 +264,12 @@ export interface CompletedBoltData {
     id: string;
     name: string;
     type: string;
+    /** Raw bolt.intent value (may be number or name). */
+    intent: string;
+    /** Resolved intent number, e.g., "001". */
+    intentNumber: string;
+    /** Resolved intent display name. */
+    intentName: string;
     completedAt: string;
     relativeTime: string;
     path: string;

--- a/vs-code-extension/src/sidebar/webviewProvider.ts
+++ b/vs-code-extension/src/sidebar/webviewProvider.ts
@@ -702,7 +702,9 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
             focusCardExpanded: data.focusCardExpanded,
             activityFilter: data.activityFilter,
             activityHeight: data.activityHeight,
-            specsFilter: data.specsFilter
+            specsFilter: data.specsFilter,
+            boltIntents: data.intents.map(i => ({ number: i.number, name: i.name })),
+            intentStats: data.intentStats
         };
 
         // Generate HTML for specs/overview views (hybrid approach)
@@ -770,7 +772,8 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
                 activityFilter: state.ui.activityFilter,
                 activityHeight: state.ui.activitySectionHeight,
                 specsFilter: state.ui.specsFilter,
-                availableStatuses: []
+                availableStatuses: [],
+                intentStats: {}
             };
         }
 
@@ -788,13 +791,61 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
         // Transform pending bolts to queue (send all, filtering done client-side)
         const upNextQueue = pendingBolts.map(bolt => this._transformQueuedBolt(bolt));
 
-        // Transform completed bolts (last 10, sorted by completion time)
+        // Transform completed bolts (all of them, sorted by completion time).
+        // The webview filters by selected intent and caps the visible count;
+        // sending the full list lets the picker show accurate per-intent results.
         const now = new Date();
         const completedBoltsData = completedBolts
             .filter(b => b.completedAt)
             .sort((a, b) => (b.completedAt?.getTime() ?? 0) - (a.completedAt?.getTime() ?? 0))
-            .slice(0, 10)
             .map(bolt => this._transformCompletedBolt(bolt, now));
+
+        // Per-intent bolt stats. Computed from the full (untruncated) bolt
+        // lists so the picker's progress bar can show accurate per-intent
+        // numbers even when completed bolts have been clipped for display.
+        type IntentBoltStats = { active: number; queued: number; done: number; blocked: number };
+        const intentStats: Record<string, IntentBoltStats> = {};
+        const ensureStats = (key: string): IntentBoltStats => {
+            if (!intentStats[key]) {
+                intentStats[key] = { active: 0, queued: 0, done: 0, blocked: 0 };
+            }
+            return intentStats[key];
+        };
+        const intentKeysFor = (bolt: Bolt): string[] => {
+            const intent = Array.from(state.intents.values()).find(
+                i => i.number === bolt.intent
+                    || i.name === bolt.intent
+                    || `${i.number}-${i.name}` === bolt.intent
+                    || path.basename(i.path) === bolt.intent
+            );
+            const keys = new Set<string>();
+            if (intent) {
+                keys.add(intent.number);
+                keys.add(intent.name);
+                keys.add(`${intent.number}-${intent.name}`);
+            }
+            keys.add(bolt.intent);
+            return Array.from(keys);
+        };
+        for (const bolt of activeBolts) {
+            for (const k of intentKeysFor(bolt)) {
+                ensureStats(k).active += 1;
+            }
+        }
+        for (const bolt of pendingBolts) {
+            for (const k of intentKeysFor(bolt)) {
+                if (bolt.isBlocked) {
+                    ensureStats(k).blocked += 1;
+                } else {
+                    ensureStats(k).queued += 1;
+                }
+            }
+        }
+        for (const bolt of completedBolts) {
+            for (const k of intentKeysFor(bolt)) {
+                ensureStats(k).done += 1;
+            }
+        }
 
         // Transform activity events
         const activityEvents: ActivityEventData[] = activityFeed.slice(0, 10).map(event => {
@@ -846,7 +897,8 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
             activityFilter: state.ui.activityFilter,
             activityHeight: state.ui.activitySectionHeight,
             specsFilter: state.ui.specsFilter,
-            availableStatuses
+            availableStatuses,
+            intentStats
         };
     }
 
@@ -857,11 +909,20 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
         const state = this._store.getState();
         const stagesComplete = bolt.stages.filter(s => s.status === ArtifactStatus.Complete).length;
         const files = this._scanBoltArtifactFiles(bolt.path);
+        const intent = Array.from(state.intents.values()).find(
+            i => i.number === bolt.intent
+                || i.name === bolt.intent
+                || `${i.number}-${i.name}` === bolt.intent
+                || path.basename(i.path) === bolt.intent
+        );
 
         return {
             id: bolt.id,
             name: bolt.id,
             type: this._formatBoltType(bolt.type),
+            intent: bolt.intent,
+            intentNumber: intent?.number ?? bolt.intent,
+            intentName: intent?.name ?? bolt.intent,
             currentStage: bolt.currentStage,
             stagesComplete,
             stagesTotal: bolt.stages.length,
@@ -905,11 +966,21 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
      * Transforms a Bolt to CompletedBoltData.
      */
     private _transformCompletedBolt(bolt: Bolt, now: Date): CompletedBoltData {
+        const state = this._store.getState();
         const files = this._scanBoltArtifactFiles(bolt.path);
+        const intent = Array.from(state.intents.values()).find(
+            i => i.number === bolt.intent
+                || i.name === bolt.intent
+                || `${i.number}-${i.name}` === bolt.intent
+                || path.basename(i.path) === bolt.intent
+        );
         return {
             id: bolt.id,
             name: bolt.id,
             type: this._formatBoltType(bolt.type),
+            intent: bolt.intent,
+            intentNumber: intent?.number ?? bolt.intent,
+            intentName: intent?.name ?? bolt.intent,
             completedAt: bolt.completedAt?.toISOString() ?? '',
             relativeTime: bolt.completedAt ? formatRelativeTime(bolt.completedAt, now) : 'unknown',
             path: bolt.path,
@@ -984,6 +1055,12 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
      */
     private _transformQueuedBolt(bolt: Bolt): QueuedBoltData {
         const state = this._store.getState();
+        const intent = Array.from(state.intents.values()).find(
+            i => i.number === bolt.intent
+                || i.name === bolt.intent
+                || `${i.number}-${i.name}` === bolt.intent
+                || path.basename(i.path) === bolt.intent
+        );
 
         return {
             id: bolt.id,
@@ -993,6 +1070,9 @@ export class SpecsmdWebviewProvider implements vscode.WebviewViewProvider {
             isBlocked: bolt.isBlocked,
             blockedBy: bolt.blockedBy,
             unblocksCount: bolt.unblocksCount,
+            intent: bolt.intent,
+            intentNumber: intent?.number ?? bolt.intent,
+            intentName: intent?.name ?? bolt.intent,
             stages: bolt.stages.map(s => ({
                 name: s.name,
                 status: this._mapStatus(s.status)

--- a/vs-code-extension/src/test/sidebar/webviewMessaging.test.ts
+++ b/vs-code-extension/src/test/sidebar/webviewMessaging.test.ts
@@ -112,7 +112,8 @@ suite('Webview Messaging Test Suite', () => {
                 activityFilter: 'all',
                 activityHeight: 200,
                 specsFilter: 'all',
-                availableStatuses: []
+                availableStatuses: [],
+                intentStats: {}
             };
 
             assert.strictEqual(data.currentIntent, null);
@@ -140,7 +141,8 @@ suite('Webview Messaging Test Suite', () => {
                 activityFilter: 'stages',
                 activityHeight: 350,
                 specsFilter: 'active',
-                availableStatuses: ['draft', 'in-progress', 'complete']
+                availableStatuses: ['draft', 'in-progress', 'complete'],
+                intentStats: {}
             };
 
             assert.strictEqual(data.focusCardExpanded, true);
@@ -157,6 +159,9 @@ suite('Webview Messaging Test Suite', () => {
                     id: 'bolt-1',
                     name: 'Test Bolt',
                     type: 'DDD',
+                    intent: 'test-intent',
+                    intentNumber: '001',
+                    intentName: 'test-intent',
                     currentStage: 'implement',
                     stagesComplete: 2,
                     stagesTotal: 5,
@@ -177,6 +182,9 @@ suite('Webview Messaging Test Suite', () => {
                         id: 'bolt-2',
                         name: 'Next Bolt',
                         type: 'Simple',
+                        intent: 'test-intent',
+                        intentNumber: '001',
+                        intentName: 'test-intent',
                         storiesCount: 2,
                         isBlocked: false,
                         blockedBy: [],
@@ -215,7 +223,8 @@ suite('Webview Messaging Test Suite', () => {
                 activityFilter: 'bolts',
                 activityHeight: 300,
                 specsFilter: 'complete',
-                availableStatuses: ['complete', 'in-progress']
+                availableStatuses: ['complete', 'in-progress'],
+                intentStats: {}
             };
 
             assert.strictEqual(data.currentIntent?.name, 'Test Intent');
@@ -233,6 +242,9 @@ suite('Webview Messaging Test Suite', () => {
                 id: 'bolt-test',
                 name: 'Test Bolt',
                 type: 'DDD',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 currentStage: 'implement',
                 stagesComplete: 2,
                 stagesTotal: 5,
@@ -263,6 +275,9 @@ suite('Webview Messaging Test Suite', () => {
                 id: 'bolt-test',
                 name: 'Test Bolt',
                 type: 'Simple',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 currentStage: null,
                 stagesComplete: 0,
                 stagesTotal: 3,
@@ -285,6 +300,9 @@ suite('Webview Messaging Test Suite', () => {
                 id: 'bolt-blocked',
                 name: 'Blocked Bolt',
                 type: 'DDD',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 storiesCount: 3,
                 isBlocked: true,
                 blockedBy: ['bolt-dep-1', 'bolt-dep-2'],
@@ -303,6 +321,9 @@ suite('Webview Messaging Test Suite', () => {
                 id: 'bolt-key',
                 name: 'Key Bolt',
                 type: 'Simple',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 storiesCount: 1,
                 isBlocked: false,
                 blockedBy: [],

--- a/vs-code-extension/src/test/sidebar/webviewProvider.test.ts
+++ b/vs-code-extension/src/test/sidebar/webviewProvider.test.ts
@@ -42,6 +42,9 @@ suite('Webview Provider Test Suite', () => {
                 id: 'bolt-test-1',
                 name: 'Test Bolt',
                 type: 'DDD',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 currentStage: 'implement',
                 stagesComplete: 2,
                 stagesTotal: 5,
@@ -80,6 +83,9 @@ suite('Webview Provider Test Suite', () => {
                 id: 'bolt-blocked',
                 name: 'Blocked Bolt',
                 type: 'Simple',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 storiesCount: 2,
                 isBlocked: true,
                 blockedBy: ['bolt-dep-1', 'bolt-dep-2'],
@@ -95,6 +101,9 @@ suite('Webview Provider Test Suite', () => {
                 id: 'bolt-ready',
                 name: 'Ready Bolt',
                 type: 'DDD',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 storiesCount: 3,
                 isBlocked: false,
                 blockedBy: [],
@@ -112,9 +121,9 @@ suite('Webview Provider Test Suite', () => {
          */
         test('queue should prioritize unblocked bolts', () => {
             const queue: QueuedBoltData[] = [
-                { id: 'b1', name: 'B1', type: 'DDD', storiesCount: 1, isBlocked: true, blockedBy: ['dep'], unblocksCount: 0, stages: [], stories: [] },
-                { id: 'b2', name: 'B2', type: 'DDD', storiesCount: 1, isBlocked: false, blockedBy: [], unblocksCount: 3, stages: [], stories: [] },
-                { id: 'b3', name: 'B3', type: 'DDD', storiesCount: 1, isBlocked: false, blockedBy: [], unblocksCount: 1, stages: [], stories: [] }
+                { id: 'b1', name: 'B1', type: 'DDD', intent: 'test', intentNumber: '001', intentName: 'test', storiesCount: 1, isBlocked: true, blockedBy: ['dep'], unblocksCount: 0, stages: [], stories: [] },
+                { id: 'b2', name: 'B2', type: 'DDD', intent: 'test', intentNumber: '001', intentName: 'test', storiesCount: 1, isBlocked: false, blockedBy: [], unblocksCount: 3, stages: [], stories: [] },
+                { id: 'b3', name: 'B3', type: 'DDD', intent: 'test', intentNumber: '001', intentName: 'test', storiesCount: 1, isBlocked: false, blockedBy: [], unblocksCount: 1, stages: [], stories: [] }
             ];
 
             // Sort: unblocked first, then by unblocksCount descending
@@ -167,7 +176,8 @@ suite('Webview Provider Test Suite', () => {
                 activityFilter: 'all',
                 activityHeight: 200,
                 specsFilter: 'all',
-                availableStatuses: []
+                availableStatuses: [],
+                intentStats: {}
             };
 
             assert.strictEqual(emptyData.currentIntent, null);
@@ -270,6 +280,9 @@ suite('Webview Provider Test Suite', () => {
                 id: 'bolt-test-1',
                 name: 'Test Bolt',
                 type: 'DDD',
+                intent: 'test-intent',
+                intentNumber: '001',
+                intentName: 'test-intent',
                 currentStage: 'implement',
                 stagesComplete: 2,
                 stagesTotal: 5,

--- a/vs-code-extension/src/webview/components/app.ts
+++ b/vs-code-extension/src/webview/components/app.ts
@@ -16,12 +16,25 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { BaseElement } from './shared/base-element.js';
 import './tabs/view-tabs.js';
 import './bolts/bolts-view.js';
+import './bolts/activity-feed.js';
 import './shared/flow-switcher.js';
 // FIRE flow components
 import './fire/fire-view.js';
 import type { TabId, TabChangeDetail } from './tabs/view-tabs.js';
 import type { BoltsViewData } from './bolts/bolts-view.js';
 import type { ActivityFilter } from './bolts/activity-feed.js';
+import type { ActivityEventData } from './bolts/activity-item.js';
+
+/**
+ * Runtime shape of the bolts payload from the extension. The extension still
+ * sends the legacy activity fields inside this payload; we split them off into
+ * dedicated state for the Activity tab.
+ */
+interface IncomingBoltsPayload extends BoltsViewData {
+    activityEvents?: ActivityEventData[];
+    activityFilter?: ActivityFilter;
+    activityHeight?: number;
+}
 import type { FlowInfo } from './shared/flow-switcher.js';
 import type { FireViewData } from './fire/fire-view.js';
 import type { FireTabId } from './fire/fire-view-tabs.js';
@@ -38,7 +51,7 @@ interface ExtensionMessage {
     specsHtml?: string;
     overviewHtml?: string;
     // Lit components approach (bolts)
-    boltsData?: BoltsViewData;
+    boltsData?: IncomingBoltsPayload;
     // Legacy support
     boltsHtml?: string;
     // Multi-flow support
@@ -67,6 +80,18 @@ export class SpecsmdApp extends BaseElement {
      */
     @state()
     private _boltsData: BoltsViewData | null = null;
+
+    /**
+     * Recent activity events (rendered in the Activity tab).
+     */
+    @state()
+    private _activityEvents: ActivityEventData[] = [];
+
+    /**
+     * Active filter for the Activity tab.
+     */
+    @state()
+    private _activityFilter: ActivityFilter = 'all';
 
     /**
      * HTML content for specs/overview views (server-rendered).
@@ -1115,14 +1140,21 @@ export class SpecsmdApp extends BaseElement {
                 @tab-change=${this._handleTabChange}
             ></view-tabs>
 
+            <div class="view-container ${this._activeTab === 'activity' ? 'active' : ''}" id="activity-view">
+                <activity-feed
+                    .events=${this._activityEvents}
+                    .filter=${this._activityFilter}
+                    @filter-change=${this._handleFilterChange}
+                    @open-file=${this._handleOpenFile}>
+                </activity-feed>
+            </div>
+
             <div class="view-container ${this._activeTab === 'bolts' ? 'active' : ''}" id="bolts-view">
                 ${this._boltsData
                     ? html`
                         <bolts-view
                             .data=${this._boltsData}
                             @toggle-focus=${this._handleToggleFocus}
-                            @filter-change=${this._handleFilterChange}
-                            @resize=${this._handleResize}
                             @start-bolt=${this._handleStartBolt}
                             @continue-bolt=${this._handleContinueBolt}
                             @view-files=${this._handleViewFiles}
@@ -1295,6 +1327,20 @@ export class SpecsmdApp extends BaseElement {
     }
 
     /**
+     * Split an incoming bolts payload into bolts state and activity-tab state.
+     */
+    private _applyBoltsPayload(payload: IncomingBoltsPayload): void {
+        const { activityEvents, activityFilter, ...bolts } = payload;
+        this._boltsData = bolts;
+        if (activityEvents !== undefined) {
+            this._activityEvents = activityEvents;
+        }
+        if (activityFilter !== undefined) {
+            this._activityFilter = activityFilter;
+        }
+    }
+
+    /**
      * Handle messages from the extension.
      */
     private _handleMessage = (event: MessageEvent<ExtensionMessage>): void => {
@@ -1306,7 +1352,7 @@ export class SpecsmdApp extends BaseElement {
                     this._activeTab = message.activeTab;
                 }
                 if (message.boltsData !== undefined) {
-                    this._boltsData = message.boltsData;
+                    this._applyBoltsPayload(message.boltsData);
                 }
                 if (message.specsHtml !== undefined) {
                     this._specsHtml = message.specsHtml;
@@ -1338,7 +1384,7 @@ export class SpecsmdApp extends BaseElement {
 
             case 'setBoltsData':
                 if (message.boltsData !== undefined) {
-                    this._boltsData = message.boltsData;
+                    this._applyBoltsPayload(message.boltsData);
                 }
                 break;
 
@@ -1364,7 +1410,7 @@ export class SpecsmdApp extends BaseElement {
                 }
                 // Reset view data when switching flows
                 if (message.boltsData !== undefined) {
-                    this._boltsData = message.boltsData;
+                    this._applyBoltsPayload(message.boltsData);
                 }
                 if (message.specsHtml !== undefined) {
                     this._specsHtml = message.specsHtml;
@@ -1422,21 +1468,7 @@ export class SpecsmdApp extends BaseElement {
      */
     private _handleFilterChange(e: CustomEvent<{ filter: ActivityFilter }>): void {
         vscode.postMessage({ type: 'activityFilter', filter: e.detail.filter });
-        // Optimistically update local state
-        if (this._boltsData) {
-            this._boltsData = { ...this._boltsData, activityFilter: e.detail.filter };
-        }
-    }
-
-    /**
-     * Handle activity section resize.
-     */
-    private _handleResize(e: CustomEvent<{ height: number }>): void {
-        vscode.postMessage({ type: 'activityResize', height: e.detail.height });
-        // Optimistically update local state
-        if (this._boltsData) {
-            this._boltsData = { ...this._boltsData, activityHeight: e.detail.height };
-        }
+        this._activityFilter = e.detail.filter;
     }
 
     /**

--- a/vs-code-extension/src/webview/components/bolts/activity-feed.ts
+++ b/vs-code-extension/src/webview/components/bolts/activity-feed.ts
@@ -24,7 +24,6 @@ export type ActivityFilter = 'all' | 'stages' | 'bolts';
  * <activity-feed
  *   .events=${events}
  *   filter="all"
- *   height="200"
  * ></activity-feed>
  * ```
  */
@@ -42,45 +41,14 @@ export class ActivityFeed extends BaseElement {
     @property({ type: String })
     filter: ActivityFilter = 'all';
 
-    /**
-     * Section height in pixels.
-     */
-    @property({ type: Number })
-    height = 200;
-
     static styles = [
         ...BaseElement.baseStyles,
         css`
             :host {
-                display: block;
-                border-top: 1px solid var(--vscode-input-border, #3c3c3c);
-                position: relative;
-            }
-
-            .resize-handle {
-                position: absolute;
-                top: 0;
-                left: 50%;
-                transform: translateX(-50%);
-                width: 48px;
-                height: 6px;
-                cursor: ns-resize;
                 display: flex;
-                align-items: center;
-                justify-content: center;
-                margin-top: -3px;
-            }
-
-            .resize-handle::after {
-                content: '';
-                width: 32px;
-                height: 4px;
-                background: var(--vscode-input-border, #3c3c3c);
-                border-radius: 2px;
-            }
-
-            .resize-handle:hover::after {
-                background: #f97316;
+                flex-direction: column;
+                height: 100%;
+                min-height: 0;
             }
 
             .header {
@@ -134,6 +102,7 @@ export class ActivityFeed extends BaseElement {
             }
 
             .list {
+                flex: 1;
                 overflow-y: auto;
             }
 
@@ -150,10 +119,8 @@ export class ActivityFeed extends BaseElement {
 
     render() {
         const filtered = this._filterEvents();
-        const listHeight = this.height - 52; // Account for header
 
         return html`
-            <div class="resize-handle" @mousedown=${this._startResize}></div>
             <div class="header">
                 <div class="title">
                     <span class="title-icon">🕐</span>
@@ -169,7 +136,7 @@ export class ActivityFeed extends BaseElement {
                     `)}
                 </div>
             </div>
-            <div class="list" style="height: ${listHeight}px;">
+            <div class="list">
                 ${filtered.length > 0
                     ? filtered.slice(0, 10).map(event => html`
                         <activity-item .event=${event}></activity-item>
@@ -198,30 +165,6 @@ export class ActivityFeed extends BaseElement {
             bubbles: true,
             composed: true
         }));
-    }
-
-    private _startResize(e: MouseEvent): void {
-        e.preventDefault();
-        const startY = e.clientY;
-        const startHeight = this.height;
-
-        const onMouseMove = (moveEvent: MouseEvent) => {
-            const delta = startY - moveEvent.clientY;
-            const newHeight = Math.max(120, Math.min(500, startHeight + delta));
-            this.dispatchEvent(new CustomEvent('resize', {
-                detail: { height: newHeight },
-                bubbles: true,
-                composed: true
-            }));
-        };
-
-        const onMouseUp = () => {
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-        };
-
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
     }
 }
 

--- a/vs-code-extension/src/webview/components/bolts/bolts-view.ts
+++ b/vs-code-extension/src/webview/components/bolts/bolts-view.ts
@@ -3,19 +3,16 @@
  */
 
 import { html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { BaseElement } from '../shared/base-element.js';
 import './current-bolts.js';
 import './focus-section.js';
 import './queue-section.js';
 import './completions-section.js';
-import './activity-feed.js';
-import type { IntentInfo, BoltStats, IntentContext } from './current-bolts.js';
+import type { IntentInfo, BoltStats, IntentContext, IntentOption } from './current-bolts.js';
 import type { ActiveBoltData } from './focus-card.js';
 import type { QueuedBoltData } from './queue-item.js';
 import type { CompletedBoltData } from './completion-item.js';
-import type { ActivityEventData } from './activity-item.js';
-import type { ActivityFilter } from './activity-feed.js';
 
 /**
  * Complete Bolts view data.
@@ -27,22 +24,25 @@ export interface BoltsViewData {
     activeBolts: ActiveBoltData[];
     upNextQueue: QueuedBoltData[];
     completedBolts: CompletedBoltData[];
-    activityEvents: ActivityEventData[];
     focusCardExpanded: boolean;
-    activityFilter: ActivityFilter;
-    activityHeight: number;
+    /** All intents in the workspace, for the intent picker. */
+    boltIntents: IntentOption[];
+    /**
+     * Per-intent bolt stats keyed by intent number / name / combined form.
+     * Computed by the backend from the full (untruncated) bolt arrays so
+     * progress is accurate even when `completedBolts` is clipped for display.
+     */
+    intentStats: Record<string, BoltStats>;
 }
 
 /**
  * Bolts view container component.
  *
  * @fires toggle-focus - When focus card is expanded/collapsed
- * @fires filter-change - When activity filter is changed
- * @fires resize - When activity section is resized
  * @fires start-bolt - When Start button is clicked
  * @fires continue-bolt - When Continue button is clicked
  * @fires view-files - When Files button is clicked
- * @fires open-file - When a file is clicked (story, artifact, or activity item)
+ * @fires open-file - When a file is clicked (story or artifact)
  * @fires open-bolt - When bolt magnifier is clicked
  *
  * @example
@@ -58,6 +58,14 @@ export class BoltsView extends BaseElement {
     @property({ type: Object })
     data!: BoltsViewData;
 
+    /**
+     * Currently selected intent number for the picker + queue filter.
+     * `null` means "not yet initialized"; defaults to currentIntent.number on
+     * first render where one is available.
+     */
+    @state()
+    private _selectedIntent: string | null = null;
+
     static styles = [
         ...BaseElement.baseStyles,
         css`
@@ -72,10 +80,6 @@ export class BoltsView extends BaseElement {
                 flex: 1;
                 overflow-y: auto;
             }
-
-            activity-feed {
-                flex-shrink: 0;
-            }
         `
     ];
 
@@ -84,11 +88,24 @@ export class BoltsView extends BaseElement {
             return html`<div>Loading...</div>`;
         }
 
+        const intents = this.data.boltIntents ?? [];
+        const selected = this._resolveSelectedIntent(intents);
+        const perIntentStats = this._computePerIntentStats(selected);
+        const filteredQueue = selected === null
+            ? this.data.upNextQueue
+            : this.data.upNextQueue.filter(b => this._boltMatchesIntent(b, selected));
+        const filteredCompletions = selected === null
+            ? this.data.completedBolts
+            : this.data.completedBolts.filter(b => this._boltMatchesIntent(b, selected));
+
         return html`
             <current-intent
-                .intent=${this.data.currentIntent}
+                .intents=${intents}
+                .selected=${selected}
+                .stats=${perIntentStats}
+                .currentIntentNumber=${this.data.currentIntent?.number ?? null}
                 .context=${this.data.currentIntentContext}
-                .stats=${this.data.stats}>
+                @intent-select=${this._handleIntentSelect}>
             </current-intent>
 
             <div class="content">
@@ -102,51 +119,71 @@ export class BoltsView extends BaseElement {
                 </focus-section>
 
                 <queue-section
-                    .bolts=${this.data.upNextQueue}
+                    .bolts=${filteredQueue}
                     @start-bolt=${this._handleStartBolt}
                     @open-file=${this._handleOpenFile}
                     @open-bolt=${this._handleOpenBolt}>
                 </queue-section>
 
                 <completions-section
-                    .bolts=${this.data.completedBolts}
+                    .bolts=${filteredCompletions}
                     @open-file=${this._handleOpenFile}
                     @open-bolt=${this._handleOpenBolt}>
                 </completions-section>
             </div>
-
-            <activity-feed
-                .events=${this.data.activityEvents}
-                .filter=${this.data.activityFilter}
-                .height=${this.data.activityHeight}
-                @filter-change=${this._handleFilterChange}
-                @resize=${this._handleResize}
-                @open-file=${this._handleOpenFile}>
-            </activity-feed>
         `;
+    }
+
+    /**
+     * Resolve the effective selected intent, falling back to the backend's
+     * current intent the first time around, then to the first available.
+     */
+    private _resolveSelectedIntent(intents: IntentOption[]): string | null {
+        if (intents.length === 0) {
+            return null;
+        }
+        if (this._selectedIntent && intents.some(i => i.number === this._selectedIntent)) {
+            return this._selectedIntent;
+        }
+        const fallback = this.data.currentIntent?.number ?? intents[0].number;
+        return fallback;
+    }
+
+    /**
+     * Look up per-intent bolt stats. Falls back to zeros if the backend
+     * didn't provide an entry for this intent.
+     */
+    private _computePerIntentStats(intentNumber: string | null): BoltStats {
+        const empty: BoltStats = { active: 0, queued: 0, done: 0, blocked: 0 };
+        if (intentNumber === null || !this.data.intentStats) {
+            return empty;
+        }
+        return this.data.intentStats[intentNumber] ?? empty;
+    }
+
+    /**
+     * Returns true if the bolt belongs to the given intent. Matches against
+     * the resolved number, name, and the raw `intent` field for safety.
+     */
+    private _boltMatchesIntent(
+        bolt: { intent: string; intentNumber: string; intentName: string },
+        intentNumber: string
+    ): boolean {
+        return (
+            bolt.intentNumber === intentNumber ||
+            bolt.intent === intentNumber ||
+            bolt.intentName === intentNumber
+        );
+    }
+
+    private _handleIntentSelect(e: CustomEvent<{ number: string }>): void {
+        e.stopPropagation();
+        this._selectedIntent = e.detail.number;
     }
 
     private _handleToggleFocus(e: CustomEvent<{ expanded: boolean }>): void {
         e.stopPropagation();
         this.dispatchEvent(new CustomEvent('toggle-focus', {
-            detail: e.detail,
-            bubbles: true,
-            composed: true
-        }));
-    }
-
-    private _handleFilterChange(e: CustomEvent<{ filter: ActivityFilter }>): void {
-        e.stopPropagation();
-        this.dispatchEvent(new CustomEvent('filter-change', {
-            detail: e.detail,
-            bubbles: true,
-            composed: true
-        }));
-    }
-
-    private _handleResize(e: CustomEvent<{ height: number }>): void {
-        e.stopPropagation();
-        this.dispatchEvent(new CustomEvent('resize', {
             detail: e.detail,
             bubbles: true,
             composed: true

--- a/vs-code-extension/src/webview/components/bolts/completion-item.ts
+++ b/vs-code-extension/src/webview/components/bolts/completion-item.ts
@@ -22,6 +22,9 @@ export interface CompletedBoltData {
     id: string;
     name: string;
     type: string;
+    intent: string;
+    intentNumber: string;
+    intentName: string;
     completedAt: string;
     relativeTime: string;
     path: string;

--- a/vs-code-extension/src/webview/components/bolts/completions-section.ts
+++ b/vs-code-extension/src/webview/components/bolts/completions-section.ts
@@ -167,7 +167,7 @@ export class CompletionsSection extends BaseElement {
 
         return html`
             <div class="header">
-                <span class="title">Recent Completions</span>
+                <span class="title">Completions</span>
                 <span class="count">${this.bolts.length} done</span>
             </div>
             <div class="list">

--- a/vs-code-extension/src/webview/components/bolts/current-bolts.ts
+++ b/vs-code-extension/src/webview/components/bolts/current-bolts.ts
@@ -1,5 +1,5 @@
 /**
- * CurrentIntent - Current intent with progress bar and statistics.
+ * CurrentIntent - Intent picker with progress bar for the selected intent.
  */
 
 import { html, css } from 'lit';
@@ -30,32 +30,61 @@ export interface BoltStats {
 export type IntentContext = 'active' | 'queued' | 'none';
 
 /**
- * Current intent component with progress bar.
+ * Intent picker option.
+ */
+export interface IntentOption {
+    number: string;
+    name: string;
+}
+
+/**
+ * Intent picker component. Lets the user choose which intent to focus on and
+ * displays a progress bar + breakdown for just that intent.
+ *
+ * @fires intent-select - Dispatched when the picker selection changes.
+ *   detail: { number: string }
  *
  * @example
  * ```html
- * <current-intent .intent=${intent} .stats=${stats}></current-intent>
+ * <current-intent
+ *   .intents=${intents}
+ *   .selected=${selected}
+ *   .stats=${perIntentStats}>
+ * </current-intent>
  * ```
  */
 @customElement('current-intent')
 export class CurrentIntent extends BaseElement {
     /**
-     * Current intent info.
+     * Available intents for the picker.
      */
-    @property({ type: Object })
-    intent: IntentInfo | null = null;
+    @property({ type: Array })
+    intents: IntentOption[] = [];
 
     /**
-     * Context for how the intent was selected.
+     * Currently selected intent number (or null for none).
      */
     @property({ type: String })
-    context: IntentContext = 'none';
+    selected: string | null = null;
 
     /**
-     * Bolt statistics.
+     * Bolt statistics for the *selected* intent.
      */
     @property({ type: Object })
     stats: BoltStats = { active: 0, queued: 0, done: 0, blocked: 0 };
+
+    /**
+     * Intent number that the backend considers active/queued (for the
+     * "(current)" marker in the dropdown).
+     */
+    @property({ type: String })
+    currentIntentNumber: string | null = null;
+
+    /**
+     * Context for how the backend-selected intent was determined.
+     */
+    @property({ type: String })
+    context: IntentContext = 'none';
 
     static styles = [
         ...BaseElement.baseStyles,
@@ -64,7 +93,10 @@ export class CurrentIntent extends BaseElement {
                 display: block;
                 padding: 16px 16px 20px 16px;
                 background: linear-gradient(135deg, var(--vscode-sideBar-background, #252526) 0%, rgba(249, 115, 22, 0.05) 100%);
-                border-top: 3px solid #f97316;
+            }
+
+            .container {
+                padding: 4px;
             }
 
             .label {
@@ -76,12 +108,31 @@ export class CurrentIntent extends BaseElement {
                 margin-bottom: 6px;
             }
 
-            .title {
+            .picker {
+                display: block;
+                width: 100%;
+                font-size: 12px;
+                font-weight: 600;
+                color: var(--foreground, #cccccc);
+                background: var(--vscode-input-background, #3c3c3c);
+                border: 1px solid var(--vscode-input-border, #3c3c3c);
+                border-radius: 4px;
+                padding: 6px 8px;
+                margin: 4px 0 20px;
+                cursor: pointer;
+            }
+
+            .picker:focus {
+                outline: 1px solid #f97316;
+                outline-offset: -1px;
+            }
+
+            .empty-title {
                 font-size: 17px;
                 font-weight: 700;
                 color: var(--foreground, #cccccc);
                 margin-bottom: 16px;
-                line-height: 1.2;
+                opacity: 0.6;
             }
 
             .progress-container {
@@ -106,10 +157,6 @@ export class CurrentIntent extends BaseElement {
             .progress-text {
                 font-size: 13px;
                 color: var(--foreground, #cccccc);
-            }
-
-            .progress-text strong {
-                font-weight: 600;
             }
 
             .progress-text .percent {
@@ -151,13 +198,12 @@ export class CurrentIntent extends BaseElement {
     ];
 
     render() {
-        // Determine label based on context
-        const label = this.context === 'queued' ? 'Next Intent' : 'Current Intent';
-
-        if (!this.intent) {
+        if (this.intents.length === 0) {
             return html`
-                <div class="label">${label}</div>
-                <div class="title" style="opacity: 0.6;">No active work</div>
+                <div class="container">
+                    <div class="label">Intent</div>
+                    <div class="empty-title">No intents detected</div>
+                </div>
             `;
         }
 
@@ -165,29 +211,50 @@ export class CurrentIntent extends BaseElement {
         const percent = total > 0 ? Math.round((this.stats.done / total) * 100) : 0;
 
         return html`
-            <div class="label">${label}</div>
-            <div class="title">${this.intent.number}-${this.intent.name}</div>
-            <div class="progress-container">
-                <div class="progress-bar">
-                    <div class="progress-fill" style="width: ${percent}%"></div>
+            <div class="container">
+                <div class="label">Intent</div>
+                <select class="picker" .value=${this.selected ?? ''} @change=${this._handleChange}>
+                    ${this.intents.map(intent => {
+                        const isCurrent = intent.number === this.currentIntentNumber;
+                        const label = `${intent.number}-${intent.name}${isCurrent ? ' (current)' : ''}`;
+                        return html`
+                            <option value=${intent.number} ?selected=${intent.number === this.selected}>
+                                ${label}
+                            </option>
+                        `;
+                    })}
+                </select>
+                <div class="progress-container">
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: ${percent}%"></div>
+                    </div>
+                    <div class="progress-text">
+                        <span class="percent">${percent}%</span> complete
+                        <span>(${this.stats.done} of ${total} bolts)</span>
+                    </div>
                 </div>
-                <div class="progress-text">
-                    <span class="percent">${percent}%</span> complete
-                    <span>(${this.stats.done} of ${total} bolts)</span>
+                <div class="breakdown">
+                    ${this.stats.active > 0 ? html`
+                        <span class="breakdown-item active">${this.stats.active} in progress</span>
+                    ` : ''}
+                    ${this.stats.queued > 0 ? html`
+                        <span class="breakdown-item">${this.stats.queued} queued</span>
+                    ` : ''}
+                    ${this.stats.blocked > 0 ? html`
+                        <span class="breakdown-item blocked">${this.stats.blocked} blocked</span>
+                    ` : ''}
                 </div>
-            </div>
-            <div class="breakdown">
-                ${this.stats.active > 0 ? html`
-                    <span class="breakdown-item active">${this.stats.active} in progress</span>
-                ` : ''}
-                ${this.stats.queued > 0 ? html`
-                    <span class="breakdown-item">${this.stats.queued} queued</span>
-                ` : ''}
-                ${this.stats.blocked > 0 ? html`
-                    <span class="breakdown-item blocked">${this.stats.blocked} blocked</span>
-                ` : ''}
             </div>
         `;
+    }
+
+    private _handleChange(e: Event): void {
+        const target = e.target as HTMLSelectElement;
+        this.dispatchEvent(new CustomEvent<{ number: string }>('intent-select', {
+            detail: { number: target.value },
+            bubbles: true,
+            composed: true
+        }));
     }
 }
 

--- a/vs-code-extension/src/webview/components/bolts/focus-card.ts
+++ b/vs-code-extension/src/webview/components/bolts/focus-card.ts
@@ -27,6 +27,9 @@ export interface ActiveBoltData {
     id: string;
     name: string;
     type: string;
+    intent: string;
+    intentNumber: string;
+    intentName: string;
     currentStage: string | null;
     stagesComplete: number;
     stagesTotal: number;

--- a/vs-code-extension/src/webview/components/bolts/queue-item.ts
+++ b/vs-code-extension/src/webview/components/bolts/queue-item.ts
@@ -29,6 +29,12 @@ export interface QueuedBoltData {
     isBlocked: boolean;
     blockedBy: string[];
     unblocksCount: number;
+    /** Raw bolt.intent value (may be number or name). */
+    intent: string;
+    /** Resolved intent number, e.g., "001". */
+    intentNumber: string;
+    /** Resolved intent display name. */
+    intentName: string;
     stages: StageData[];
     stories: QueueStoryData[];
 }

--- a/vs-code-extension/src/webview/components/tabs/view-tabs.ts
+++ b/vs-code-extension/src/webview/components/tabs/view-tabs.ts
@@ -9,7 +9,7 @@ import { BaseElement } from '../shared/base-element.js';
 /**
  * Valid tab identifiers.
  */
-export type TabId = 'bolts' | 'specs' | 'overview';
+export type TabId = 'activity' | 'bolts' | 'specs' | 'overview';
 
 /**
  * Tab definition with icon and label.
@@ -24,6 +24,7 @@ interface TabDef {
  * Available tabs configuration.
  */
 const TABS: TabDef[] = [
+    { id: 'activity', icon: '\uD83D\uDD52', label: 'Activity' },  // Clock
     { id: 'bolts', icon: '\u26A1', label: 'Bolts' },     // Lightning bolt
     { id: 'specs', icon: '\uD83D\uDCCB', label: 'Specs' },  // Clipboard
     { id: 'overview', icon: '\uD83D\uDCCA', label: 'Overview' }  // Chart


### PR DESCRIPTION
Take it or leave it. I needed a more organized way to see it. 

## Summary

- **New Activity tab** split out of the Bolts tab as a peer (`Activity → Bolts → Specs → Overview`). Fills the whole pane; resize handle and persisted height removed.
- **Intent picker on the Bolts tab** replaces the static \"Current/Next Intent\" display. Dropdown lists every intent in the workspace; backend-active intent marked `(current)`. Selection is in-session, not persisted across reloads.
- **Per-intent progress bar** — percent complete and breakdown (in-progress / queued / blocked) now reflect only the selected intent. Backend computes stats from the full bolt arrays so older completions still count.
- **Filtered Up Next** — only queued/blocked bolts for the selected intent.
- **Filtered Completions** (now titled \"Completions\") — only completions for the selected intent. Removed the global 10-completion cap so per-intent lists are accurate. Globally-recent completions remain available via the Activity tab.
- **Styling tweaks** — smaller picker font (12px / 600), inner container with 4px breathing room around the picker + progress block, removed the orange top border on the Bolts tab for consistency with sibling tabs.

## Backend plumbing

- `QueuedBoltData`, `ActiveBoltData`, `CompletedBoltData` each gained `intent`, `intentNumber`, `intentName` fields, resolved by matching the bolt's raw `intent` string against `state.intents` by number, name, combined `\${number}-\${name}`, and folder basename (covers full-folder-name conventions like `007-platform-tenant-access`).
- `boltsData` postMessage payload now includes `boltIntents: { number, name }[]` and `intentStats: Record<string, BoltStats>`.
- Webview `app.ts` splits the legacy activity fields off the incoming bolts payload into dedicated state used by the Activity tab.

## Test plan

- [x] \`npm run compile\` clean (extension + webview)
- [x] \`npm test\` — all 412 tests pass
- [ ] F5 the extension against a real workspace and confirm:
  - [ ] Tab order is Activity, Bolts, Specs, Overview
  - [ ] Activity tab fills the pane; filter + open-file still work
  - [ ] Bolts tab has the intent dropdown; current intent is marked `(current)`
  - [ ] Switching intents updates the progress bar, Up Next, and Completions consistently
  - [ ] Intents with only old completed bolts (pushed past the previous 10-cap) now show accurate progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)