### PR TITLE
fix(kiro): install agent commands as Kiro CLI skills so /specsmd-* slash commands work

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ specs.md is **IDE and AI-agnostic**—your specs and agents are portable markdow
 | **GitHub Copilot** | Agents in `.github/agents/` (`.agent.md` format) |
 | **Google Antigravity** | Agents in `.agent/agents/` |
 | **Windsurf** | Rules in `.windsurf/rules/` |
-| **Amazon Kiro** | Steering in `.kiro/steering/` |
+| **Amazon Kiro** | Skills (slash commands) in `.kiro/skills/` |
 | **Gemini CLI** | Commands in `.gemini/commands/` (`.toml` format) |
 | **Cline** | Rules in `.clinerules/` |
 | **Roo Code** | Commands in `.roo/commands/` |

--- a/src/flows/aidlc/commands/construction-agent.md
+++ b/src/flows/aidlc/commands/construction-agent.md
@@ -13,7 +13,7 @@ description: Building phase agent - execute bolts through DDD stages (model, tes
 You are now the **Construction Agent** for specsmd AI-DLC.
 
 **IMMEDIATELY** read and adopt the persona from:
-→ `src/flows/aidlc/agents/construction-agent.md`
+→ `.specsmd/aidlc/agents/construction-agent.md`
 
 ---
 

--- a/src/flows/aidlc/commands/inception-agent.md
+++ b/src/flows/aidlc/commands/inception-agent.md
@@ -13,7 +13,7 @@ description: Planning phase agent - requirements gathering, story creation, and 
 You are now the **Inception Agent** for specsmd AI-DLC.
 
 **IMMEDIATELY** read and adopt the persona from:
-→ `src/flows/aidlc/agents/inception-agent.md`
+→ `.specsmd/aidlc/agents/inception-agent.md`
 
 ---
 

--- a/src/flows/aidlc/commands/operations-agent.md
+++ b/src/flows/aidlc/commands/operations-agent.md
@@ -13,7 +13,7 @@ description: Deployment phase agent - build, deploy, verify, and monitor release
 You are now the **Operations Agent** for specsmd AI-DLC.
 
 **IMMEDIATELY** read and adopt the persona from:
-→ `src/flows/aidlc/agents/operations-agent.md`
+→ `.specsmd/aidlc/agents/operations-agent.md`
 
 ---
 

--- a/src/lib/installers/KiroInstaller.js
+++ b/src/lib/installers/KiroInstaller.js
@@ -4,6 +4,17 @@ const fs = require('fs-extra');
 const CLIUtils = require('../cli-utils');
 const { theme } = CLIUtils;
 
+/**
+ * Installer for Kiro CLI.
+ *
+ * Kiro CLI exposes user-defined slash commands through "Agent Skills":
+ * a skill lives in `.kiro/skills/<name>/SKILL.md` and becomes the `/<name>`
+ * slash command (see https://kiro.dev/docs/cli/skills/). Steering files
+ * (`.kiro/steering/`) are always-on context and are NOT invocable as slash
+ * commands, so installing the agent commands there meant `/specsmd-*` never
+ * showed up in Kiro CLI. We install skills instead so the commands work
+ * out of the box.
+ */
 class KiroInstaller extends ToolInstaller {
     get key() {
         return 'kiro';
@@ -14,7 +25,9 @@ class KiroInstaller extends ToolInstaller {
     }
 
     get commandsDir() {
-        return path.join('.kiro', 'steering');
+        // Skills are the slash-command mechanism in Kiro CLI.
+        // (uninstall/rollback iterate this dir and remove `specsmd-*` entries.)
+        return path.join('.kiro', 'skills');
     }
 
     get detectPath() {
@@ -22,18 +35,90 @@ class KiroInstaller extends ToolInstaller {
     }
 
     /**
-     * Override to install commands and create specs symlink for simple flow
+     * Install each flow command as a Kiro CLI skill (`.kiro/skills/<name>/SKILL.md`)
+     * so it is discoverable as a `/<name>` slash command.
      */
     async installCommands(flowPath, config) {
-        // Install commands (default behavior)
-        const installedCommands = await super.installCommands(flowPath, config);
+        const targetSkillsDir = this.commandsDir;
+        console.log(theme.dim(`  Installing skills to ${targetSkillsDir}/...`));
+        await fs.ensureDir(targetSkillsDir);
 
-        // For simple flow, create symlink to make specs visible in Kiro
+        const commandsSourceDir = path.join(flowPath, 'commands');
+        if (!await fs.pathExists(commandsSourceDir)) {
+            console.log(theme.warning(`  No commands folder found at ${commandsSourceDir}`));
+            return [];
+        }
+
+        const commandFiles = await fs.readdir(commandsSourceDir);
+        const installedFiles = [];
+
+        for (const cmdFile of commandFiles) {
+            if (!cmdFile.endsWith('.md')) continue;
+
+            try {
+                const sourcePath = path.join(commandsSourceDir, cmdFile);
+                const content = await fs.readFile(sourcePath, 'utf8');
+                const commandName = cmdFile.replace(/\.md$/, '');
+                const prefix = (config && config.command && config.command.prefix) ? `${config.command.prefix}-` : '';
+                // Skill name == slash command. Lowercase letters, numbers, hyphens only.
+                const skillName = `specsmd-${prefix}${commandName}`.toLowerCase();
+
+                const { description, body } = this.parseFrontmatter(content);
+
+                // Build SKILL.md with Kiro CLI frontmatter (name + description required).
+                const skillContent = [
+                    '---',
+                    `name: ${skillName}`,
+                    `description: ${this.sanitizeDescription(description) || 'specsmd agent'}`,
+                    '---',
+                    '',
+                    body
+                ].join('\n');
+
+                const skillDir = path.join(targetSkillsDir, skillName);
+                await fs.ensureDir(skillDir);
+                await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent, 'utf8');
+
+                installedFiles.push(skillName);
+            } catch (err) {
+                console.log(theme.warning(`  Failed to install ${cmdFile}: ${err.message}`));
+            }
+        }
+
+        CLIUtils.displayStatus('', `Installed ${installedFiles.length} skills for ${this.name}`, 'success');
+
+        // For simple flow, create symlink to make specs visible in Kiro.
         if (flowPath.includes('simple')) {
             await this.createSpecsSymlink();
         }
 
-        return installedCommands;
+        return installedFiles;
+    }
+
+    /**
+     * Parse YAML frontmatter from a markdown command file.
+     * Returns the description and the body (without the frontmatter block).
+     */
+    parseFrontmatter(content) {
+        const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+        if (!match) return { description: '', body: content };
+
+        const frontmatter = match[1];
+        const body = match[2];
+        const descMatch = frontmatter.match(/description:\s*["']?(.+?)["']?\s*$/m);
+        return {
+            description: descMatch ? descMatch[1] : '',
+            body: body.trim()
+        };
+    }
+
+    /**
+     * Kiro skill descriptions are single-line and capped at 1024 chars.
+     */
+    sanitizeDescription(description) {
+        if (!description) return '';
+        const oneLine = description.replace(/\s+/g, ' ').trim();
+        return oneLine.length > 1024 ? oneLine.slice(0, 1021) + '...' : oneLine;
     }
 
     /**


### PR DESCRIPTION
## Problem

The Kiro CLI installer wrote each flow command into `.kiro/steering/`. Kiro CLI
treats steering files as always-on context, not invocable commands, so the
`/specsmd-master-agent` (and other) slash commands never appeared — the documented
"run `/specsmd-master-agent`" next step didn't work out of the box.

Two smaller inconsistencies compounded this:
- Three of the four AI-DLC command files pointed agents at the source-repo path
  `src/flows/aidlc/agents/...` instead of the installed path `.specsmd/aidlc/agents/...`,
  so even if a command was invoked, the persona read would fail in an installed project.
- The README tool table still described the Kiro integration as steering files.

## Change

- **`KiroInstaller`** now installs each command as a Kiro CLI **skill** at
  `.kiro/skills/specsmd-<name>/SKILL.md` with the required `name` / `description`
  frontmatter. Skills are Kiro CLI's slash-command mechanism (a skill named
  `specsmd-master-agent` becomes `/specsmd-master-agent`). `commandsDir` moved to
  `.kiro/skills`, so the existing uninstall/rollback logic (which removes `specsmd-*`
  entries) keeps working.
- **Fixed persona paths** in `inception-agent.md`, `construction-agent.md`, and
  `operations-agent.md` to reference `.specsmd/aidlc/agents/...`.
- **README** tool table now reads "Skills (slash commands) in `.kiro/skills/`".

## Scope: this fixes all flows, not just AI-DLC

The `KiroInstaller` change is **flow-agnostic** — `installCommands(flowPath, ...)`
iterates over `<flowPath>/commands/*.md` and writes each as a skill, so the same fix
applies to whichever flow is installed. Reported against AI-DLC (issue #75,
`/specsmd-master-agent`), it equally enables:

| Flow | command file(s) | installed skill(s) |
|------|-----------------|--------------------|
| Simple | `agent.md` | `/specsmd-agent` |
| FIRE | `fire.md`, `fire-planner.md`, `fire-builder.md` | `/specsmd-fire`, `/specsmd-fire-planner`, `/specsmd-fire-builder` |
| AI-DLC | `master/inception/construction/operations-agent.md` | `/specsmd-master-agent`, … |

Verified by running this branch's installer against each flow — the expected
`.kiro/skills/specsmd-*/SKILL.md` entries are created in every case. (The
`aidlc/commands/*-agent.md` persona-path fixes are AI-DLC-specific and independent of
this; the Simple/FIRE command files have no equivalent path issue.)

## Testing

- `npm test` — 416 passing
- `npm run lint:md` — clean
- Installer verified for all three flows against this branch: each flow's commands
  land as `.kiro/skills/specsmd-*/SKILL.md` with valid `name` / `description`
  frontmatter (no command files left in `.kiro/steering/`).
- Behavior verified in an installed workspace on Kiro CLI 2.8.1:
  - **V3 engine** (`kiro-cli --v3`): typing `/specsmd-agent` (and the other
    `specsmd-*` skills) in the interactive REPL resolves and activates the skill,
    reading its persona from the installed `.specsmd/.../agents/...` path.
  - **Default V2 engine** (`kiro-cli chat`): the skills are discovered and usable —
    the model loads and follows `SKILL.md` when asked by description — but the
    `/specsmd-*` **slash commands do not resolve** ("unrecognized subcommand"), both
    when typed in the REPL and when passed as an argument.
  - Slash commands are an interactive-REPL feature; passing `/specsmd-*` as a
    command-line argument fails on both engines (the CLI's built-in command parser
    intercepts the leading `/`).

## Requirements

The skill files install on any Kiro CLI with skills support and are usable by
description on both agent engines. The **`/specsmd-*` slash commands resolve only
under the V3 agent engine** (`kiro-cli --v3`; the feature shipped in CLI **>= 2.1**:
https://kiro.dev/changelog/cli/2-1/). On the default V2 `kiro-cli chat`, the skills
install and are usable but are not exposed as `/`-commands.
